### PR TITLE
New UID type and edge handling for mutations

### DIFF
--- a/client.go
+++ b/client.go
@@ -3,6 +3,7 @@ package quirk
 import (
 	"context"
 	"sync"
+	"unsafe"
 
 	"github.com/damienfamed75/quirk/logging"
 )
@@ -40,7 +41,7 @@ func NewClient(confs ...ClientConfiguration) *Client {
 // will be added or a single node. Then the function will return a
 // map of the returned successful UIDs with the key being the predicate
 // key value. By default this will be the "name" predicate value.
-func (c *Client) InsertNode(ctx context.Context, dg DgraphClient, o *Operation) (uidMap map[string]string, err error) {
+func (c *Client) InsertNode(ctx context.Context, dg DgraphClient, o *Operation) (map[string]UID, error) {
 	if o.SetMultiStruct != nil && o.SetSingleStruct != nil {
 		return nil, &Error{
 			Msg:      msgTooManyMutationFields,
@@ -49,7 +50,8 @@ func (c *Client) InsertNode(ctx context.Context, dg DgraphClient, o *Operation) 
 		}
 	}
 
-	uidMap = make(map[string]string)
+	var err error
+	uidMap := make(map[string]string)
 
 	switch {
 	case o.SetMultiStruct != nil:
@@ -73,7 +75,7 @@ func (c *Client) InsertNode(ctx context.Context, dg DgraphClient, o *Operation) 
 		err = c.mutateMulti(ctx, dg, tmp, uidMap, c.mutateSingleDupleNode)
 	}
 
-	return
+	return *(*map[string]UID)(unsafe.Pointer(&uidMap)), err
 }
 
 // GetPredicateKey returns the name of the field(predicate) that will

--- a/constant.go
+++ b/constant.go
@@ -22,6 +22,7 @@ const (
 	blankDefault = "data"
 	whenRDF      = `<%s> <when> "%d"^^<xs:int> .`
 	rdfBase      = "_:%s <%s> \"%v\""
+	rdfReference = "_:%s <%s> <%v>"
 	rdfEnd       = " .\n"
 	queryfunc    = "%s(func: eq(%s, %q), first: 1){uid}\n"
 )

--- a/examples/edges/main.go
+++ b/examples/edges/main.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"log"
+
+	"github.com/damienfamed75/quirk"
+
+	"github.com/dgraph-io/dgo"
+	"github.com/dgraph-io/dgo/protos/api"
+	"google.golang.org/grpc"
+)
+
+var drop bool
+
+// Person is the structure to hold the node's data.
+// When using quirk you must have tags associated with your fields.
+// The first quirk parameter is the name of the predicate in Dgraph.
+// The second parameter (which always is "unique") specifies if this
+// field should be unique throughout the graph.
+type Person struct {
+	Name   string `quirk:"name"`
+	SSN    string `quirk:"ssn,unique"`
+	Policy string `quirk:"policy,unique"`
+}
+
+func main() {
+	flag.BoolVar(&drop, "d", false, "Drop-All before running example.")
+	flag.Parse()
+
+	// Dial for Dgraph using grpc.
+	conn, err := grpc.Dial("127.0.0.1:9080", grpc.WithInsecure())
+	if err != nil {
+		log.Fatalf("Failed when dialing grpc [%v]", err)
+	}
+	defer conn.Close()
+
+	// Create a new Dgraph client for our mutations.
+	dg := dgo.NewDgraphClient(api.NewDgraphClient(conn))
+
+	// Drop all pre-existing data in the graph.
+	if drop {
+		err = dg.Alter(context.Background(), &api.Operation{DropAll: true})
+		if err != nil {
+			log.Fatalf("Alteration error with DropAll [%v]\n", err)
+		}
+	}
+
+	// Alter the schema to be equal to our schema variable.
+	err = dg.Alter(context.Background(), &api.Operation{Schema: `
+		name: string @index(hash) .
+		ssn: string @index(hash) @upsert .
+		policy: string @index(hash) @upsert .
+	`})
+	if err != nil {
+		log.Fatalf("Alteration error with setting schema [%v]\n", err)
+	}
+
+	// Create the Quirk Client with a debug logger.
+	// The debug logger is just for demonstration purposes or for debugging.
+	c := quirk.NewClient(quirk.WithLogger(quirk.NewDebugLogger()))
+	if err != nil {
+		log.Fatalf("Failed to create Quirk Client [%v]\n", err)
+	}
+
+	// Use the quirk client to insert a single node.
+	uidMap, err := c.InsertNode(context.Background(), dg, &quirk.Operation{
+		SetSingleStruct: &Person{Name: "John", SSN: "126", Policy: "JKL"}})
+	if err != nil {
+		log.Fatalf("Error when inserting nodes [%v]\n", err)
+	}
+
+	uidMap, err = c.InsertNode(context.Background(), dg, &quirk.Operation{
+		SetSingleDupleNode: &quirk.DupleNode{
+			Identifier: "Damien",
+			Duples: []quirk.Duple{
+				quirk.Duple{Predicate: "name", Object: "Damien"},
+				quirk.Duple{Predicate: "ssn", Object: "127"},
+				quirk.Duple{Predicate: "policy", Object: "LKJ"},
+				quirk.Duple{Predicate: "friendsWith", Object: uidMap["John"]},
+			},
+		},
+	})
+
+	// Finally print out the successful UIDs.
+	// The key is typically going to be either your
+	// assigned "name" predicate or if you don't have this
+	// then it will be an incremented character/s.
+	// Note: If you wish to use another predicate beside "name"
+	// you may set that when creating the client and using
+	// quirk.WithPredicateKey(predicateName string)
+	for k, v := range uidMap {
+		log.Printf("UIDMap: [%s] [%s]\n", k, v)
+	}
+}

--- a/model.go
+++ b/model.go
@@ -95,6 +95,11 @@ func (d *DupleNode) Unique() (duples []Duple) {
 // tag, or the empty string. It does not include the leading comma.
 type tagOptions string
 
+// UID is used to identify the ID's given to the user and retrieved back to
+// be put as the object of a predicate.
+// This way quirk can handle the UID how they're supposed to be handled.
+type UID string
+
 // queryDecode is our type when unmarshalling a query response.
 type queryDecode map[string][]struct{ UID *string }
 

--- a/newnode.go
+++ b/newnode.go
@@ -12,8 +12,14 @@ import (
 func setNewNode(ctx context.Context, txn dgraphTxn, b builder,
 	identifier string, dat *DupleNode) (string, error) {
 	for _, d := range dat.Duples {
-		// get any optional XML datatype knowledge based on the value.
-		fmt.Fprintf(b, rdfBase+d.dataType+rdfEnd, identifier, d.Predicate, d.Object)
+		d.dataType = checkType(d.Object)
+		if uid, ok := d.Object.(UID); ok {
+			// Use the UID format instead of the regular object.
+			fmt.Fprintf(b, rdfReference+d.dataType+rdfEnd, identifier, d.Predicate, uid)
+		} else {
+			// get any optional XML datatype knowledge based on the value.
+			fmt.Fprintf(b, rdfBase+d.dataType+rdfEnd, identifier, d.Predicate, d.Object)
+		}
 	}
 
 	// Use our transaction to execute a mutation to add our new node.

--- a/parse.go
+++ b/parse.go
@@ -43,7 +43,7 @@ func (c *Client) reflectMaps(d interface{}) *DupleNode {
 			Predicate: tag, // first quirk tag.
 			Object:    elem.Field(i).Interface(),
 			IsUnique:  opt == tagUnique, // if the second option is "unique"
-			dataType:  checkType(elem.Field(i).Interface()),
+			// dataType:  checkType(elem.Field(i).Interface()),
 		}
 
 		if tag == c.predicateKey {


### PR DESCRIPTION
Added a new UID string type to return
- `InsertNode` now returns `map[string]UID` instead of `map[string]string`
- Using a `quirk.UID` type for an Object value will be handled according as a `UID` in Dgraph
- Used `unsafe` to convert the `map[string]string` to `map[string]UID`
- Moved `checkType` call to the `newNode` function
- Added new example of using the `UID` type in `examples/edges/`